### PR TITLE
Delete idea card from local storage

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ ideaBoard.addEventListener("click", deleteIdea);
 saveButton.addEventListener("click", saveIdea);
 title.addEventListener("input", showSave);
 body.addEventListener("input", showSave);
-ideaBoard.addEventListener("click", favoriteIdea); 
+ideaBoard.addEventListener("click", favoriteIdea);
 toggleStarredIdeasButton.addEventListener("click", toggleStarredIdeas);
 window.addEventListener("load", renderPage);
 
@@ -57,7 +57,7 @@ function renderPage() {
 
 function render(arrayToRender) {
     var markup = "";
-    
+
     for (var i = 0; i < arrayToRender.length; i++) {
       var imageSource = getImageSourceFromIdea(arrayToRender[i]);
         markup += `
@@ -123,6 +123,7 @@ function deleteIdea(event) {
         ideas.splice(i, 1);
       }
     }
+    localStorage.setItem("ideas", JSON.stringify(ideas));
     render(ideas);
   }
 }


### PR DESCRIPTION
# Pull Request Template
## Description

When deleteIdea function is invoked when delete "x" is pressed on idea card, local storage is updated to reflect changes and on refresh, page only shows cards that were not deleted.

Fixes # (issue)
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
#### Please add appreciative feedback in the comment section of this PR after reveiwing.
